### PR TITLE
Use the SSH key in ~/docker.env instead of requiring a hard-coded one.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -16,7 +16,9 @@ mkdir /var/run/sshd
 mkdir -p /root/.ssh
 chmod 700 /root/.ssh
 chmod 600 /root/.ssh/*
-echo 'YOUR PUBLIC KEY GOES HERE' >> ~/.ssh/authorized_keys
+if [ ! -z "$SSH_PUBLIC_KEY" ]; then
+  echo "$SSH_PUBLIC_KEY" >> ~/.ssh/authorized_keys
+fi
 chown -Rf root:root /root/.ssh
 
 # configure sshd to block authentication via password


### PR DESCRIPTION
Here's a change to use the SSH key in ~/docker.env for generating the accepted SSH keys for the Docker container.

This allows for pushing the ready image directly to DockerHub, which means that users no longer have to necessarily build the image themselves.